### PR TITLE
Generate a new set of unused recovery counters each time

### DIFF
--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -7,6 +7,7 @@ class DeviseOtpAddTo<%= table_name.camelize %> < ActiveRecord::Migration[7.0]
       t.boolean   :otp_mandatory,        :default => false, :null => false
       t.datetime  :otp_enabled_on
       t.integer   :otp_failed_attempts,  :default => 0, :null => false
+      t.integer   :otp_recovery_counter,  default: 0, null: false
       t.text      :otp_recovery_counters, default: "[]"
       t.datetime  :otp_recovery_forced_until
       t.string    :otp_persistence_seed
@@ -25,7 +26,7 @@ class DeviseOtpAddTo<%= table_name.camelize %> < ActiveRecord::Migration[7.0]
   def self.down
     change_table :<%= table_name %> do |t|
       t.remove :otp_auth_secret, :otp_recovery_secret, :otp_enabled, :otp_mandatory, :otp_enabled_on, :otp_session_challenge,
-          :otp_challenge_expires, :otp_failed_attempts, :otp_persistence_seed, :otp_recovery_forced_until, :otp_recovery_counters,
+          :otp_challenge_expires, :otp_failed_attempts, :otp_persistence_seed, :otp_recovery_forced_until, :otp_recovery_counter, :otp_recovery_counters,
           :otp_by_email_enabled, :otp_by_email_counter, :otp_by_email_token_expires
     end
   end

--- a/test/dummy/db/migrate/20250321093611_devise_otp_add_to_users.rb
+++ b/test/dummy/db/migrate/20250321093611_devise_otp_add_to_users.rb
@@ -1,12 +1,13 @@
-class DeviseOtpAddToAdmins < ActiveRecord::Migration[7.0]
+class DeviseOtpAddToUsers < ActiveRecord::Migration[7.0]
   def self.up
-    change_table :admins do |t|
+    change_table :users do |t|
       t.string    :otp_auth_secret
       t.string    :otp_recovery_secret
       t.boolean   :otp_enabled,          :default => false, :null => false
       t.boolean   :otp_mandatory,        :default => false, :null => false
       t.datetime  :otp_enabled_on
       t.integer   :otp_failed_attempts,  :default => 0, :null => false
+      t.integer   :otp_recovery_counter,  default: 0, null: false
       t.text      :otp_recovery_counters, default: "[]"
       t.datetime  :otp_recovery_forced_until
       t.string    :otp_persistence_seed
@@ -18,14 +19,14 @@ class DeviseOtpAddToAdmins < ActiveRecord::Migration[7.0]
       t.string    :otp_session_challenge
       t.datetime  :otp_challenge_expires
     end
-    add_index :admins, :otp_session_challenge,  :unique => true
-    add_index :admins, :otp_challenge_expires
+    add_index :users, :otp_session_challenge,  :unique => true
+    add_index :users, :otp_challenge_expires
   end
 
   def self.down
-    change_table :admins do |t|
+    change_table :users do |t|
       t.remove :otp_auth_secret, :otp_recovery_secret, :otp_enabled, :otp_mandatory, :otp_enabled_on, :otp_session_challenge,
-          :otp_challenge_expires, :otp_failed_attempts, :otp_persistence_seed, :otp_recovery_forced_until, :otp_recovery_counters,
+          :otp_challenge_expires, :otp_failed_attempts, :otp_persistence_seed, :otp_recovery_forced_until, :otp_recovery_counter, :otp_recovery_counters,
           :otp_by_email_enabled, :otp_by_email_counter, :otp_by_email_token_expires
     end
   end

--- a/test/dummy/db/migrate/20250321093622_devise_otp_add_to_admins.rb
+++ b/test/dummy/db/migrate/20250321093622_devise_otp_add_to_admins.rb
@@ -1,12 +1,13 @@
-class DeviseOtpAddToUsers < ActiveRecord::Migration[7.0]
+class DeviseOtpAddToAdmins < ActiveRecord::Migration[7.0]
   def self.up
-    change_table :users do |t|
+    change_table :admins do |t|
       t.string    :otp_auth_secret
       t.string    :otp_recovery_secret
       t.boolean   :otp_enabled,          :default => false, :null => false
       t.boolean   :otp_mandatory,        :default => false, :null => false
       t.datetime  :otp_enabled_on
       t.integer   :otp_failed_attempts,  :default => 0, :null => false
+      t.integer   :otp_recovery_counter,  default: 0, null: false
       t.text      :otp_recovery_counters, default: "[]"
       t.datetime  :otp_recovery_forced_until
       t.string    :otp_persistence_seed
@@ -18,14 +19,14 @@ class DeviseOtpAddToUsers < ActiveRecord::Migration[7.0]
       t.string    :otp_session_challenge
       t.datetime  :otp_challenge_expires
     end
-    add_index :users, :otp_session_challenge,  :unique => true
-    add_index :users, :otp_challenge_expires
+    add_index :admins, :otp_session_challenge,  :unique => true
+    add_index :admins, :otp_challenge_expires
   end
 
   def self.down
-    change_table :users do |t|
+    change_table :admins do |t|
       t.remove :otp_auth_secret, :otp_recovery_secret, :otp_enabled, :otp_mandatory, :otp_enabled_on, :otp_session_challenge,
-          :otp_challenge_expires, :otp_failed_attempts, :otp_persistence_seed, :otp_recovery_forced_until, :otp_recovery_counters,
+          :otp_challenge_expires, :otp_failed_attempts, :otp_persistence_seed, :otp_recovery_forced_until, :otp_recovery_counter, :otp_recovery_counters,
           :otp_by_email_enabled, :otp_by_email_counter, :otp_by_email_token_expires
     end
   end


### PR DESCRIPTION
update `generate_otp_recovery_counters!` to generate a new set on every call and advance `otp_recovery_counter`