### PR TITLE
Populate otp secrets when calling generators

### DIFF
--- a/lib/devise-otp/version.rb
+++ b/lib/devise-otp/version.rb
@@ -1,5 +1,5 @@
 module Devise
   module OTP
-    VERSION = "1.4.1"
+    VERSION = "1.3.2"
   end
 end

--- a/lib/devise-otp/version.rb
+++ b/lib/devise-otp/version.rb
@@ -1,5 +1,5 @@
 module Devise
   module OTP
-    VERSION = "1.3.1"
+    VERSION = "1.4.1"
   end
 end

--- a/lib/devise_otp_authenticatable/controllers/helpers.rb
+++ b/lib/devise_otp_authenticatable/controllers/helpers.rb
@@ -122,7 +122,7 @@ module DeviseOtpAuthenticatable
       #
       def otp_authenticator_token_image(resource)
         content_tag(:div, class: "qrcode-container") do
-          raw RQRCode::QRCode.new(resource.otp_provisioning_uri).as_svg(:module_size => 5, :viewbox => true, :use_path => true)
+          raw resource.otp_authenticator_qrcode
         end
       end
 


### PR DESCRIPTION
OTP secrets are populated by the controller. It is more intuitive to ensure secrets are present when calling otp generators when using those methods directly in the application. So that end user does not have to remember to populate the secrets manually.

Don't memoize otp generators.

Make otp_authenticator_qrcode availabe in the model.