### PR TITLE
update variable name+extend session when new email token generated

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,7 +17,8 @@ en:
         valid_refresh: 'Thank you, your credentials were accepted.'
         invalid_refresh: 'Sorry, you provided the wrong credentials.'
         too_many_failed_attempts: 'Too many failed OTP attempts. Please enter a recovery code.'
-        otp_by_email_code_sent: 'Please enter the OTP code we have sent to your email.'
+        otp_by_email_code_sent: 'Please enter the OTP code sent to your email.'
+        otp_by_email_code_resent: 'Resent OTP Code to your email. Please check your email.'
         otp_by_email_code_expired: 'OTP code has expired. Please check your email for a new one.'
       credentials_refresh:
         title: 'Please enter your password again.'

--- a/lib/devise-otp.rb
+++ b/lib/devise-otp.rb
@@ -82,8 +82,8 @@ module Devise
   #
   # email otp token if valid for
   #
-  mattr_accessor :otp_by_email_code_valid_for
-  @@otp_by_email_code_valid_for = 5.minutes
+  mattr_accessor :otp_by_email_code_timeout
+  @@otp_by_email_code_timeout = 5.minutes
 
   #
   # add PublicHelpers to helpers class variable to ensure that per-mapping helpers are present.

--- a/lib/devise-otp/version.rb
+++ b/lib/devise-otp/version.rb
@@ -1,5 +1,5 @@
 module Devise
   module OTP
-    VERSION = "1.3.3"
+    VERSION = "1.3.4"
   end
 end

--- a/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
+++ b/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
@@ -4,6 +4,7 @@ require "rqrcode"
 module Devise::Models
   module OtpAuthenticatable
     extend ActiveSupport::Concern
+    EMAIL_OTP_EXTRA_SESSION_TIME = 30.seconds
 
     included do
       scope :with_valid_otp_challenge, lambda { |time| where("otp_challenge_expires > ?", time) }
@@ -180,7 +181,7 @@ module Devise::Models
         otp_by_email_token_expires: time + self.class.otp_by_email_code_timeout,
         otp_by_email_counter: self.otp_by_email_counter + 1,
       )
-      extend_otp_challenge_timeout(self.class.otp_by_email_code_timeout + 30.seconds)
+      extend_otp_challenge_timeout(self.class.otp_by_email_code_timeout + EMAIL_OTP_EXTRA_SESSION_TIME)
     end
 
     def otp_by_email_token_expired?(time = now)

--- a/lib/devise_otp_authenticatable/routes.rb
+++ b/lib/devise_otp_authenticatable/routes.rb
@@ -20,7 +20,7 @@ module ActionDispatch::Routing
           path: mapping.path_names[:credentials], controller: controllers[:otp_credentials] do
           get :refresh, action: "get_refresh"
           put :refresh, action: "set_refresh"
-          get :resend_email, action: "get_resend_email"
+          get :resend_email, action: "resend_email"
         end
 
       end

--- a/lib/generators/devise_otp/install_generator.rb
+++ b/lib/generators/devise_otp/install_generator.rb
@@ -49,7 +49,7 @@ module DeviseOtp
   #config.otp_recovery_timeout = 30.minutes
 
   # Email OTP code valid for
-  #config.otp_by_email_code_valid_for = 5.minutes
+  #config.otp_by_email_code_timeout = 5.minutes
 
         CONTENT
 

--- a/test/dummy/config/initializers/devise.rb
+++ b/test/dummy/config/initializers/devise.rb
@@ -280,5 +280,5 @@ Devise.setup do |config|
   #config.otp_recovery_timeout = 30.minutes
 
   # Email OTP code valid for
-  #config.otp_by_email_code_valid_for = 5.minutes
+  #config.otp_by_email_code_timeout = 5.minutes
 end

--- a/test/models/otp_authenticatable_test.rb
+++ b/test/models/otp_authenticatable_test.rb
@@ -253,14 +253,14 @@ class OtpAuthenticatableTest < ActiveSupport::TestCase
     user = User.first
     user.update!(otp_by_email_counter: 0, otp_by_email_token_expires: nil)
     now = Time.now.utc.round(6)
-    otp_by_email_code_valid_for = user.class.otp_by_email_code_valid_for
+    otp_by_email_code_timeout = user.class.otp_by_email_code_timeout
 
     user.otp_by_email_advance_counter(now)
     assert_equal user.otp_by_email_counter, 1
-    assert user.otp_by_email_token_expires.eql?(now+otp_by_email_code_valid_for)
+    assert user.otp_by_email_token_expires.eql?(now+otp_by_email_code_timeout)
 
     user.otp_by_email_advance_counter(now+1)
     assert_equal user.otp_by_email_counter, 2
-    assert user.otp_by_email_token_expires.eql?(now+otp_by_email_code_valid_for+1)
+    assert user.otp_by_email_token_expires.eql?(now+otp_by_email_code_timeout+1)
   end
 end


### PR DESCRIPTION
This pull request includes several changes to improve the OTP email functionality and refactor the codebase for better maintainability. The most important changes include adding a new `resend_email` action, updating the OTP token timeout configuration, and refactoring methods related to OTP by email.

### OTP Email Functionality Improvements:
* Added `resend_email` action to handle resending OTP emails and updated related before actions to include `resend_email` (`app/controllers/devise_otp/devise/otp_credentials_controller.rb`). [[1]](diffhunk://#diff-f410cf07f473976114f03156580aa3afce28fb8774494ea10ea371f1929fbce5L7-R28) [[2]](diffhunk://#diff-f410cf07f473976114f03156580aa3afce28fb8774494ea10ea371f1929fbce5L69-R73)
* Refactored the method `set_otp_state` to use a new helper method `set_email_token_remaining_time` for setting the OTP email token remaining time (`app/controllers/devise_otp/devise/otp_credentials_controller.rb`). [[1]](diffhunk://#diff-f410cf07f473976114f03156580aa3afce28fb8774494ea10ea371f1929fbce5L112-R113) [[2]](diffhunk://#diff-f410cf07f473976114f03156580aa3afce28fb8774494ea10ea371f1929fbce5R122-R126)
* Updated localization strings to include a message for resent OTP code (`config/locales/en.yml`).

### Configuration and Refactoring:
* Renamed `otp_by_email_code_valid_for` to `otp_by_email_code_timeout` and updated related configurations and methods (`lib/devise-otp.rb`, `lib/devise_otp_authenticatable/models/otp_authenticatable.rb`, `lib/generators/devise_otp/install_generator.rb`, `test/dummy/config/initializers/devise.rb`). [[1]](diffhunk://#diff-a5587863dd0a943142d75e8a02ed272c86751ed799b5a06b4d57afd8d5a7b31fL85-R86) [[2]](diffhunk://#diff-5beafaa89b894307ae8949f7d2dd83b39ef9d062dc14ecad4486dd63ff7adf0fL15-R15) [[3]](diffhunk://#diff-30475e43d58622f39b35ff64ae0f09d5208cd6bccd468186903d1344890882cfL52-R52) [[4]](diffhunk://#diff-57d1a0061dbafdf4b99ea7c8e37df73ed079979d6cdb8190772ed85f94624ebcL283-R283)
* Added `extend_otp_challenge_timeout` method to extend the OTP challenge timeout when the OTP email token is advanced (`lib/devise_otp_authenticatable/models/otp_authenticatable.rb`). [[1]](diffhunk://#diff-5beafaa89b894307ae8949f7d2dd83b39ef9d062dc14ecad4486dd63ff7adf0fR97-R100) [[2]](diffhunk://#diff-5beafaa89b894307ae8949f7d2dd83b39ef9d062dc14ecad4486dd63ff7adf0fL176-R183)

### Version Update:
* Updated the version of the `devise-otp` gem to `1.3.4` (`lib/devise-otp/version.rb`).