### PR TITLE
Reset otp_failed_attempts at the moment we force recovery

### DIFF
--- a/lib/devise-otp/version.rb
+++ b/lib/devise-otp/version.rb
@@ -1,5 +1,5 @@
 module Devise
   module OTP
-    VERSION = "1.3.5"
+    VERSION = "1.3.6"
   end
 end

--- a/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
+++ b/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
@@ -158,7 +158,12 @@ module Devise::Models
 
     def bump_failed_attempts(time = now)
       self.otp_failed_attempts += 1
-      self.otp_recovery_forced_until = time + self.class.otp_recovery_timeout if max_failed_attempts_exceeded?
+
+      if max_failed_attempts_exceeded?
+        self.otp_recovery_forced_until = time + self.class.otp_recovery_timeout
+        self.otp_failed_attempts = 0
+      end
+
       self.save!
     end
 

--- a/test/models/otp_authenticatable_test.rb
+++ b/test/models/otp_authenticatable_test.rb
@@ -214,7 +214,7 @@ class OtpAuthenticatableTest < ActiveSupport::TestCase
     assert_nil user.otp_recovery_forced_until
   end
 
-  test "bump_failed_attempts increases otp_failed_attempts by 1 and sets otp_recovery_forced_until if otp_max_failed_attempts is exceeded" do
+  test "bump_failed_attempts increases otp_failed_attempts by 1. If otp_max_failed_attempts is exceeded sets otp_failed_attempts to 0 and sets otp_recovery_forced_until" do
     user = User.first
     otp_max_failed_attempts = user.class.otp_max_failed_attempts
     otp_recovery_timeout = user.class.otp_recovery_timeout
@@ -231,7 +231,7 @@ class OtpAuthenticatableTest < ActiveSupport::TestCase
     assert_nil user.otp_recovery_forced_until
 
     user.bump_failed_attempts(now)
-    assert_equal user.otp_failed_attempts, otp_max_failed_attempts+1
+    assert_equal user.otp_failed_attempts, 0
     assert user.otp_recovery_forced_until.eql?(now+otp_recovery_timeout)
   end
 


### PR DESCRIPTION
Allow another set of failed attempts after recovery timeout ended.

The reason behind it is to prevent the case when user is forced into recovery immediately after the timeout has ended.

1. User has recovery forced
2. Waits for recovery timeout to end
3. Inputs incorrect token
4. Forced into another 30 minutes of recovery timeout instantly