### PR TITLE
use >= check for max failed attempts to prevent extra attempt

### DIFF
--- a/app/controllers/devise_otp/devise/otp_credentials_controller.rb
+++ b/app/controllers/devise_otp/devise/otp_credentials_controller.rb
@@ -56,7 +56,8 @@ module DeviseOtp
           # TODO: deduplicate code copied from #show
           if resource.within_recovery_timeout?
             @otp_recovery_forced = true
-            message_id = :too_many_failed_attempts unless @recovery
+            message_id = :too_many_failed_attempts unless @recovery  # skip message if already in recovery page
+            @recovery = true
 
           elsif !@recovery && @otp_by_email && resource.otp_by_email_token_expired?
             message_id = :otp_by_email_code_expired

--- a/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
+++ b/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
@@ -153,7 +153,7 @@ module Devise::Models
     end
 
     def max_failed_attempts_exceeded?
-      otp_failed_attempts > self.class.otp_max_failed_attempts
+      otp_failed_attempts >= self.class.otp_max_failed_attempts
     end
 
     def bump_failed_attempts(time = now)


### PR DESCRIPTION
1. user got one extra failed attempt which resulted in bad notice message
![Screenshot 2025-04-02 at 12 34 22](https://github.com/user-attachments/assets/ab5a30ef-ca8f-40d0-98da-33c301de130c)




2. when going into `forced_recovery` mode, only set the `too_many_failed_attempts` message the first time, we need to show proper error messages (like `:invalid_token') the other times