### PR TITLE
[IAM-42310] Fix OTP replay vulnerability

### DIFF
--- a/app/controllers/devise_otp/devise/otp_credentials_controller.rb
+++ b/app/controllers/devise_otp/devise/otp_credentials_controller.rb
@@ -49,6 +49,7 @@ module DeviseOtp
         end
 
         if resource.otp_challenge_valid? && resource.validate_otp_token(@token, @recovery)
+          resource.record_last_otp!(@token)
           resource.reset_failed_attempts
 
           sign_in(resource_name, resource)

--- a/lib/devise-otp/version.rb
+++ b/lib/devise-otp/version.rb
@@ -1,5 +1,5 @@
 module Devise
   module OTP
-    VERSION = "1.4.3"
+    VERSION = "1.5.0"
   end
 end

--- a/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
+++ b/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
@@ -5,6 +5,7 @@ module Devise::Models
   module OtpAuthenticatable
     extend ActiveSupport::Concern
     EMAIL_OTP_EXTRA_SESSION_TIME = 30.seconds
+    OTP_REPLAY_WINDOW_SECONDS = 30.seconds  # based on 30 second default interval used by authenticator apps
 
     included do
       scope :with_valid_otp_challenge, lambda { |time| where("otp_challenge_expires > ?", time) }
@@ -123,7 +124,7 @@ module Devise::Models
     alias_method :valid_otp_token?, :validate_otp_token
 
     def otp_replay?(token)
-      (token == otp_last_token) && (otp_last_used_at.present? && otp_last_used_at > (30 * (self.class.otp_drift_window+1)).seconds.ago)
+      (token == otp_last_token) && (otp_last_used_at.present? && otp_last_used_at.after?( ( (self.class.otp_drift_window+1)*OTP_REPLAY_WINDOW_SECONDS).ago) )
     end
 
     def validate_otp_by_email(token, time = now)

--- a/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
+++ b/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
@@ -79,7 +79,9 @@ module Devise::Models
         :otp_recovery_counters => "[]",
         :otp_failed_attempts => 0,
         :otp_by_email_token_expires => nil,
-        :otp_by_email_counter => 0
+        :otp_by_email_counter => 0,
+        :otp_last_token => nil,
+        :otp_last_used_at => nil,
       )
     end
 
@@ -108,6 +110,7 @@ module Devise::Models
 
     def validate_otp_token(token, recovery = false)
       return false if token.blank?
+      return false if otp_replay?(token)
 
       if recovery
         validate_otp_recovery_token token
@@ -118,6 +121,10 @@ module Devise::Models
       end
     end
     alias_method :valid_otp_token?, :validate_otp_token
+
+    def otp_replay?(token)
+      (token == otp_last_token) && (otp_last_used_at.present? && otp_last_used_at > Time.now.ago(30 * (self.class.otp_drift_window+1)))
+    end
 
     def validate_otp_by_email(token, time = now)
       return if otp_by_email_token_expired?(time)
@@ -196,7 +203,20 @@ module Devise::Models
     end
 
     def reset_failed_attempts
-      update!(otp_failed_attempts: 0, otp_recovery_forced_until: nil, otp_recovery_failed_attempts: 0, otp_recovery_blocked_until: nil)
+      update!(
+        otp_failed_attempts: 0,
+        otp_recovery_forced_until: nil,
+        otp_recovery_failed_attempts: 0,
+        otp_recovery_blocked_until: nil,
+        otp_by_email_token_expires: nil,
+      )
+    end
+
+    def record_last_otp!(last_used_code)
+      update!(
+        otp_last_token: last_used_code,
+        otp_last_used_at: Time.current
+      )
     end
 
     def otp_by_email_token

--- a/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
+++ b/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
@@ -123,7 +123,7 @@ module Devise::Models
     alias_method :valid_otp_token?, :validate_otp_token
 
     def otp_replay?(token)
-      (token == otp_last_token) && (otp_last_used_at.present? && otp_last_used_at > Time.now.ago(30 * (self.class.otp_drift_window+1)))
+      (token == otp_last_token) && (otp_last_used_at.present? && otp_last_used_at > (30 * (self.class.otp_drift_window+1)).seconds.ago)
     end
 
     def validate_otp_by_email(token, time = now)

--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -21,6 +21,9 @@ class DeviseOtpAddTo<%= table_name.camelize %> < ActiveRecord::Migration[7.0]
 
       t.string    :otp_session_challenge
       t.datetime  :otp_challenge_expires
+
+      t.string    :otp_last_token
+      t.datetime  :otp_last_used_at
     end
     add_index :<%= table_name %>, :otp_session_challenge,  :unique => true
     add_index :<%= table_name %>, :otp_challenge_expires

--- a/test/dummy/db/migrate/20250402094358_devise_otp_add_to_admins.rb
+++ b/test/dummy/db/migrate/20250402094358_devise_otp_add_to_admins.rb
@@ -21,6 +21,9 @@ class DeviseOtpAddToAdmins < ActiveRecord::Migration[7.0]
 
       t.string    :otp_session_challenge
       t.datetime  :otp_challenge_expires
+
+      t.string    :otp_last_token
+      t.datetime  :otp_last_used_at
     end
     add_index :admins, :otp_session_challenge,  :unique => true
     add_index :admins, :otp_challenge_expires

--- a/test/dummy/db/migrate/20250402094403_devise_otp_add_to_users.rb
+++ b/test/dummy/db/migrate/20250402094403_devise_otp_add_to_users.rb
@@ -21,6 +21,9 @@ class DeviseOtpAddToUsers < ActiveRecord::Migration[7.0]
 
       t.string    :otp_session_challenge
       t.datetime  :otp_challenge_expires
+
+      t.string    :otp_last_token
+      t.datetime  :otp_last_used_at
     end
     add_index :users, :otp_session_challenge,  :unique => true
     add_index :users, :otp_challenge_expires

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,0 +1,110 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.0].define(version: 2025_04_02_094403) do
+  create_table "admins", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at", precision: nil
+    t.datetime "remember_created_at", precision: nil
+    t.integer "sign_in_count", default: 0
+    t.datetime "current_sign_in_at", precision: nil
+    t.datetime "last_sign_in_at", precision: nil
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.integer "failed_attempts", default: 0
+    t.string "unlock_token"
+    t.datetime "locked_at", precision: nil
+    t.string "authentication_token"
+    t.string "otp_auth_secret"
+    t.string "otp_recovery_secret"
+    t.boolean "otp_enabled", default: false, null: false
+    t.boolean "otp_mandatory", default: false, null: false
+    t.datetime "otp_enabled_on"
+    t.integer "otp_failed_attempts", default: 0, null: false
+    t.integer "otp_recovery_counter", default: 0, null: false
+    t.text "otp_recovery_counters", default: "[]"
+    t.datetime "otp_recovery_forced_until"
+    t.string "otp_persistence_seed"
+    t.integer "otp_recovery_failed_attempts", default: 0, null: false
+    t.datetime "otp_recovery_blocked_until"
+    t.boolean "otp_by_email_enabled", default: false, null: false
+    t.integer "otp_by_email_counter", default: 0, null: false
+    t.datetime "otp_by_email_token_expires"
+    t.string "otp_session_challenge"
+    t.datetime "otp_challenge_expires"
+    t.string "otp_last_token"
+    t.datetime "otp_last_used_at"
+    t.index ["authentication_token"], name: "index_admins_on_authentication_token", unique: true
+    t.index ["email"], name: "index_admins_on_email", unique: true
+    t.index ["otp_challenge_expires"], name: "index_admins_on_otp_challenge_expires"
+    t.index ["otp_session_challenge"], name: "index_admins_on_otp_session_challenge", unique: true
+    t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
+    t.index ["unlock_token"], name: "index_admins_on_unlock_token", unique: true
+  end
+
+  create_table "posts", force: :cascade do |t|
+    t.string "title"
+    t.text "body"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at", precision: nil
+    t.datetime "remember_created_at", precision: nil
+    t.integer "sign_in_count", default: 0
+    t.datetime "current_sign_in_at", precision: nil
+    t.datetime "last_sign_in_at", precision: nil
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.integer "failed_attempts", default: 0
+    t.string "unlock_token"
+    t.datetime "locked_at", precision: nil
+    t.string "authentication_token"
+    t.string "otp_auth_secret"
+    t.string "otp_recovery_secret"
+    t.boolean "otp_enabled", default: false, null: false
+    t.boolean "otp_mandatory", default: false, null: false
+    t.datetime "otp_enabled_on"
+    t.integer "otp_failed_attempts", default: 0, null: false
+    t.integer "otp_recovery_counter", default: 0, null: false
+    t.text "otp_recovery_counters", default: "[]"
+    t.datetime "otp_recovery_forced_until"
+    t.string "otp_persistence_seed"
+    t.integer "otp_recovery_failed_attempts", default: 0, null: false
+    t.datetime "otp_recovery_blocked_until"
+    t.boolean "otp_by_email_enabled", default: false, null: false
+    t.integer "otp_by_email_counter", default: 0, null: false
+    t.datetime "otp_by_email_token_expires"
+    t.string "otp_session_challenge"
+    t.datetime "otp_challenge_expires"
+    t.string "otp_last_token"
+    t.datetime "otp_last_used_at"
+    t.index ["authentication_token"], name: "index_users_on_authentication_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["otp_challenge_expires"], name: "index_users_on_otp_challenge_expires"
+    t.index ["otp_session_challenge"], name: "index_users_on_otp_session_challenge", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
+  end
+end

--- a/test/integration/refresh_test.rb
+++ b/test/integration/refresh_test.rb
@@ -72,7 +72,7 @@ class RefreshTest < ActionDispatch::IntegrationTest
   end
 
   test "user should be finally be able to access their settings, and just password is enough" do
-    user = enable_otp_and_sign_in_with_otp
+    enable_otp_and_sign_in_with_otp
 
     sleep(2)
     visit user_otp_token_path

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -18,7 +18,7 @@ class SignInTest < ActionDispatch::IntegrationTest
   end
 
   test "a new user, just signed in, should be able to see and click the 'Enable Two-Factor Authentication' link" do
-    user = sign_user_in
+    sign_user_in
 
     visit user_otp_token_path
     assert page.has_content?("Disabled")
@@ -92,7 +92,8 @@ class SignInTest < ActionDispatch::IntegrationTest
   test "fail same token reuse authentication" do
     user = enable_otp_and_sign_in
 
-    freeze_time do
+    travel_to Time.current
+    begin
       token = ROTP::TOTP.new(user.otp_auth_secret).at(Time.now)
 
       submit_token(token)
@@ -106,6 +107,8 @@ class SignInTest < ActionDispatch::IntegrationTest
 
       assert_equal user_otp_credential_path, current_path
       assert page.has_content? "The token you provided was invalid."
+    ensure
+      travel_back
     end
   end
 

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -89,6 +89,26 @@ class SignInTest < ActionDispatch::IntegrationTest
     assert_equal root_path, current_path
   end
 
+  test "fail same token reuse authentication" do
+    user = enable_otp_and_sign_in
+
+    freeze_time do
+      token = ROTP::TOTP.new(user.otp_auth_secret).at(Time.now)
+
+      submit_token(token)
+      assert_equal root_path, current_path
+
+      sign_out
+
+      travel 20.seconds do
+        sign_in_with_otp(user, token)
+      end
+
+      assert_equal user_otp_credential_path, current_path
+      assert page.has_content? "The token you provided was invalid."
+    end
+  end
+
   test "should fail if the the challenge times out" do
     old_timeout = User.otp_authentication_timeout
     User.otp_authentication_timeout = 1.second

--- a/test/integration_tests_helper.rb
+++ b/test/integration_tests_helper.rb
@@ -29,9 +29,18 @@ class ActionDispatch::IntegrationTest
 
   def enable_otp_and_sign_in_with_otp
     enable_otp_and_sign_in.tap do |user|
-      fill_in "token", with: ROTP::TOTP.new(user.otp_auth_secret).at(Time.now)
-      click_button "Submit Token"
+      submit_token(ROTP::TOTP.new(user.otp_auth_secret).at(Time.now))
     end
+  end
+
+  def submit_token(token)
+    fill_in "token", with: token
+    click_button "Submit Token"
+  end
+
+  def sign_in_with_otp(user, token)
+    sign_user_in(user)
+    submit_token(token)
   end
 
   def create_user_with_otp_secrets
@@ -55,8 +64,7 @@ class ActionDispatch::IntegrationTest
   end
 
   def otp_challenge_for(user)
-    fill_in "token", with: ROTP::TOTP.new(user.otp_auth_secret).at(Time.now)
-    click_button "Submit Token"
+    submit_token(ROTP::TOTP.new(user.otp_auth_secret).at(Time.now))
   end
 
   def disable_otp

--- a/test/models/otp_authenticatable_test.rb
+++ b/test/models/otp_authenticatable_test.rb
@@ -111,7 +111,7 @@ class OtpAuthenticatableTest < ActiveSupport::TestCase
     u = User.first
     u.populate_otp_secrets!
     u.enable_otp!
-    challenge = u.generate_otp_challenge!(1.second)
+    u.generate_otp_challenge!(1.second)
     sleep(2)
     assert_equal false, u.otp_challenge_valid?
   end


### PR DESCRIPTION
### Context

Ticket #[42310](https://oysterhr.kanbanize.com/ctrl_board/11/cards/42310/details/)

Attacker can intercept users input and reuse the same OTP (both email and authenticator app codes) to login to system

### Solution

1. after successful login reset email otp's expire time, this enforces a new token to be generated and the old one to be invalidated
2. add `otp_last_token` and `otp_last_used_at` fields to keep last authenticator app used tokens, with these we will invalidate the the token if used again in the lifecycle of the original token 
Note: TOTP generates same codes as it is time based, thus there is a slime possibility of user getting same code after for example 10 hours ! so we limit the reuse check to 2 minute window